### PR TITLE
chartboost插屏bug修改

### DIFF
--- a/chartboost/src/main/java/com/yumi/android/sdk/ads/adapter/chartboost/ChartboostInterstitialAdapter.java
+++ b/chartboost/src/main/java/com/yumi/android/sdk/ads/adapter/chartboost/ChartboostInterstitialAdapter.java
@@ -106,6 +106,7 @@ public class ChartboostInterstitialAdapter extends
 				public void didClickInterstitial(String location) {
 					ZplayDebug.d(TAG, "chartboost interstitial clicked", onoff);
 					layerClicked(-99f, -99f);
+					layerClosed();
 					super.didClickInterstitial(location);
 				}
 


### PR DESCRIPTION
解决chartboost平台广告点击之后,chartboost平台自动关闭广告界面,不返回closed回调,导致聚合插屏逻辑被终止