### PR TITLE
fix, faking onAttached method for displaying ads

### DIFF
--- a/iqzone/src/main/java/com/yumi/android/sdk/ads/adapter/iqzone/IQZoneInterstitialAdapter.java
+++ b/iqzone/src/main/java/com/yumi/android/sdk/ads/adapter/iqzone/IQZoneInterstitialAdapter.java
@@ -46,6 +46,7 @@ public class IQZoneInterstitialAdapter extends YumiCustomerInterstitialAdapter {
     protected void init() {
         ZplayDebug.d(TAG, "IQZone Interstitial init", onoff);
         imdInterstitialAdManager = new IQzoneInterstitialAdManager(getContext(), getProvider().getKey1(), newAdEventsListener());
+        imdInterstitialAdManager.onAttached(getActivity());
     }
 
     private AdEventsListener newAdEventsListener() {

--- a/iqzone/src/main/java/com/yumi/android/sdk/ads/adapter/iqzone/IQZoneMediaAdapter.java
+++ b/iqzone/src/main/java/com/yumi/android/sdk/ads/adapter/iqzone/IQZoneMediaAdapter.java
@@ -68,6 +68,7 @@ public class IQZoneMediaAdapter extends YumiCustomerMediaAdapter {
     protected void init() {
         ZplayDebug.d(TAG, "IQZone Video init", onoff);
         imdRewardedVideoAdManager = new IQzoneInterstitialAdManager(getContext(), getProvider().getKey1(), newAdEventsListener());
+        imdRewardedVideoAdManager.onAttached(getActivity());
     }
 
     private AdEventsListener newAdEventsListener() {


### PR DESCRIPTION
目前玉米聚合视频、插屏没有 onResume / onPause 生命周期回调，测试发现如果 IQZone 不添加 onAttached 方法，广告会一直失败。现将广告初始化后立即调用 onAttached 方法来模拟 onResume 生命周期，自测可行。